### PR TITLE
added: include only files specified in grunt task and support for renaming paths more flexibly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
-  - "0.8"
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "6"
 before_script:
   - npm install -g grunt-cli

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,9 +36,19 @@ module.exports = function(grunt) {
     },
 
     i18next: {
-      locales:{
+      spreadOut: {
         src: [Path.LOCALES],
         dest: Path.BUILD_PATH
+      },
+      together: {
+        cwd: 'test/sample/loc',
+        expand: true,
+        src: ['*/'],
+        include: ['**/*.json', '!**/ignore-this.json'],
+        rename: function(dest, src) {
+          return dest + src + 'translation-combined.json';
+        },
+        dest: Path.BUILD_PATH + '/'
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-# grunt-i18next [![Build Status](https://travis-ci.org/sabarasaba/grunt-i18next.png?branch=master)](https://travis-ci.org/sabarasaba/grunt-i18next)
+# grunt-i18next [![Build Status](https://travis-ci.org/i18next/grunt-i18next.png?branch=master)](https://travis-ci.org/i18next/grunt-i18next)
 
 > Bundle language resource files for i18next.
 
 
-
 ## Getting Started
-This plugin requires Grunt `~0.4.0`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
@@ -19,17 +17,32 @@ Once the plugin has been installed, it may be enabled inside your Gruntfile with
 grunt.loadNpmTasks('grunt-i18next');
 ```
 
-*This plugin was designed to work with Grunt 0.4.x. If you're still using grunt v0.3.x it's strongly recommended that [you upgrade](http://gruntjs.com/upgrading-from-0.3-to-0.4).*
-
-
-
 ## i18next task
 _Run this task with the `grunt i18next` command._
 
-Task targets, files and options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
+This multi task supports all the file mapping format Grunt supports. Please read [Globbing patterns](http://gruntjs.com/configuring-tasks#globbing-patterns) and [Building the files object dynamically](http://gruntjs.com/configuring-tasks#building-the-files-object-dynamically) for additional details.Note the following task configuration properties: 
+
+###### src
+This required property specifies the *folders* (not files!) the plugin should look for translation json files.
+
+###### include
+This optional custom property specifies which files to include. If it is omitted, all json files will be included in the specified `src` folders. Any grunt globbing pattern can be used (array or string).
+
+###### dest
+The destination folder.
+
+###### include
+See grunt documentation. Used to rewrite destination URLs. Amongst other things it allows one task to create multiple output files.
+
+###### cwd
+See grunt documentation. 
+
+For more general information on specifying targets, files and options see the grunt [Configuring Tasks](http://gruntjs.com/configuring-tasks) guide. 
 
 
-### Usage Examples
+### Simple Usage Example
+
+This task finds any files in locales folders and merges the ones that have the same file name. The resulting merged files are placed in _application/languages_.
 
 ```js
 i18next: {
@@ -40,8 +53,27 @@ i18next: {
 }
 ```
 
-This task supports all the file mapping format Grunt supports. Please read [Globbing patterns](http://gruntjs.com/configuring-tasks#globbing-patterns) and [Building the files object dynamically](http://gruntjs.com/configuring-tasks#building-the-files-object-dynamically) for additional details.
+### Complex Usage Example
 
+This task finds .json files in folders that are direct descendents of _src/languages_, excluding files called "ignore-this.json". The task merges all the files in each src folder separately. The resulting files have file names "translation-combined.json", and are placed under _application/languages_ in their own subfolders that match the src subfolders.
+
+```js
+i18next: {
+  complex: {
+    cwd: 'src/languages',
+    expand: true,
+    src: ['*/'],
+    include: ['**/*.json', '!**/ignore-this.json'],
+    rename: function(dest, src) {
+      return dest + '/' + src + 'translation-combined.json';
+    },
+    dest: 'application/languages'
+  }
+}
+```
 
 ## Release History
- * 2013-09-28   v0.0.1   First version
+
+* 2016-07-19 v1.0.0 Added support for include and rename
+* 2015-03-04 v0.0.2 Renamed to grunt-i18next
+* 2013-09-28 v0.0.1 First version

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# grunt-i18next [![Build Status](https://travis-ci.org/i18next/grunt-i18next.png?branch=master)](https://travis-ci.org/i18next/grunt-i18next)
+# grunt-i18next [![Build Status](https://travis-ci.org/i18next/grunt-i18next.png?branch=master)](https://travis-ci.org/i18next/grunt-i18next) [![npm version](https://badge.fury.io/js/grunt-i18next.svg)](https://badge.fury.io/js/grunt-i18next) [![devDependency Status](https://david-dm.org/i18next/grunt-i18next/dev-status.svg)](https://david-dm.org/i18next/grunt-i18next#info=devDependencies)
 
-> Bundle language resource files for i18next.
+Bundle language resource files for i18next.
 
 
 ## Getting Started
@@ -22,19 +22,19 @@ _Run this task with the `grunt i18next` command._
 
 This multi task supports all the file mapping format Grunt supports. Please read [Globbing patterns](http://gruntjs.com/configuring-tasks#globbing-patterns) and [Building the files object dynamically](http://gruntjs.com/configuring-tasks#building-the-files-object-dynamically) for additional details.Note the following task configuration properties: 
 
-###### src
+##### src
 This required property specifies the *folders* (not files!) the plugin should look for translation json files.
 
-###### include
+##### include
 This optional custom property specifies which files to include. If it is omitted, all json files will be included in the specified `src` folders. Any grunt globbing pattern can be used (array or string).
 
-###### dest
+##### dest
 The destination folder.
 
-###### include
+##### rename
 See grunt documentation. Used to rewrite destination URLs. Amongst other things it allows one task to create multiple output files.
 
-###### cwd
+##### cwd
 See grunt documentation. 
 
 For more general information on specifying targets, files and options see the grunt [Configuring Tasks](http://gruntjs.com/configuring-tasks) guide. 
@@ -74,6 +74,6 @@ i18next: {
 
 ## Release History
 
-* 2016-07-19 v1.0.0 Added support for include and rename
+* 2016-07-19 v1.0.0 Added support for include and rename
 * 2015-03-04 v0.0.2 Renamed to grunt-i18next
-* 2013-09-28 v0.0.1 First version
+* 2013-09-28 v0.0.1 First version

--- a/package.json
+++ b/package.json
@@ -14,12 +14,10 @@
   "bugs": {
     "url": "https://github.com/i18next/grunt-i18next/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/i18next/grunt-i18next/blob/master/LICENSE-MIT"
-    }
-  ],
+  "licenses": [{
+    "type": "MIT",
+    "url": "https://github.com/i18next/grunt-i18next/blob/master/LICENSE-MIT"
+  }],
   "engines": {
     "node": ">= 0.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "grunt-i18next",
   "description": "Bundle language resource files for i18next.",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "homepage": "https://github.com/i18next/grunt-i18next",
   "author": {
     "name": "Ignacio Rivas",
     "url": "http://github.com/sabarasaba"
   },
+  "contributors": [{
+    "name": "Martijn van de Rijdt",
+    "email": "martijn@enketo.org"
+  }],
   "repository": {
     "type": "git",
     "url": "git://github.com/i18next/grunt-i18next.git"
@@ -19,7 +23,7 @@
     "url": "https://github.com/i18next/grunt-i18next/blob/master/LICENSE-MIT"
   }],
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.10.0"
   },
   "scripts": {
     "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -25,13 +25,10 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.6.2",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-nodeunit": "~0.2.1",
-    "grunt": "~0.4.0"
-  },
-  "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt-contrib-jshint": "1.0.x",
+    "grunt-contrib-clean": "1.0.x",
+    "grunt-contrib-nodeunit": "1.0.x",
+    "grunt": "1.0.x"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/i18next.js
+++ b/tasks/i18next.js
@@ -11,13 +11,12 @@ module.exports = function(grunt) {
   'use strict';
 
   grunt.registerMultiTask('i18next', 'Build locale files.', function() {
-    var that = this,
-        len = this.filesSrc.length,
-        outputDir,
-        outputFile,
-        originalFile,
-        destFile,
-        merged;
+    var that = this;
+    var x;
+    var y;
+
+    // default to all json files
+    this.data.include = this.data.include || '**/*.json';
 
     var mergeRecursive = function(obj1, obj2) {
       for (var p in obj2) {
@@ -37,10 +36,18 @@ module.exports = function(grunt) {
       return obj1;
     };
 
-    var iterateTroughFiles = function(abspath, rootdir, subdir, filename){
-      if (abspath.indexOf('/.svn') === -1){
-        outputDir = that.data.dest;
-        outputFile = outputDir + '/' + filename;
+    var iterateTroughFiles = function(abspath, rootdir, subdir, filename) {
+      var outputDir;
+      var outputFile;
+      var originalFile;
+      var destFile;
+      var merged;
+
+      if (grunt.file.isMatch(that.data.include, abspath)) {
+
+        // if data.rename is not defined the dest has to be a single file
+        outputFile = (that.data.rename) ? that.files[x].dest : that.data.dest + '/' + filename;
+        outputDir = outputFile.substring(0, outputFile.lastIndexOf('/'));
 
         // If output dir doesnt exists, then create it
         if (!grunt.file.exists(outputDir)) {
@@ -63,8 +70,10 @@ module.exports = function(grunt) {
       }
     };
 
-    for (var x = 0; x < len; x++) {
-      grunt.file.recurse(this.filesSrc[x], iterateTroughFiles);
+    for (x = 0; x < this.files.length; x++) {
+      for (y = 0; y < this.files[x].src.length; y++) {
+        grunt.file.recurse(this.files[x].src[y], iterateTroughFiles);
+      }
     }
   });
 };

--- a/test/i18next_test.js
+++ b/test/i18next_test.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 
 var path = 'test/sample/languages/';
 
-exports.i18next = {
+exports.spreadOut = {
   main: function(test) {
     'use strict';
 
@@ -30,6 +30,33 @@ exports.i18next = {
     test.equal(enBundle['widget-b'].has_been, 'has been ', 'The has_been attribute of widget-b should be "has been".');
     test.equal(nestedBundle['en']['widget-a'].title, 'Activities', 'The nested title of widget-a should be Activities.');
     test.equal(nestedBundle['en']['widget-b'].has_been, 'has been ', 'The nested has_been attribute of widget-b should be "has been".');
+
+    test.done();
+  }
+};
+
+
+exports.together = {
+  main: function(test) {
+    'use strict';
+
+    test.expect(1);
+
+    test.ok(fs.existsSync(path + 'en/translation-combined.json'), 'The -combined bundle should exist.');
+
+    test.done();
+  },
+
+  checkBundleContents: function(test) {
+    'use strict';
+
+    test.expect(3);
+
+    var enBundle = JSON.parse(fs.readFileSync(path + 'en/translation-combined.json', 'utf8'));
+
+    test.equal(enBundle['widget-a'].title, 'Activities', 'The title of widget-a should be Activities.');
+    test.equal(enBundle['widget-b'].has_been, 'has been ', 'The has_been attribute of widget-b should be "has been".');
+    test.equal(enBundle['widget-c'], undefined, 'The file not included in the "include" property should be ignored.');
 
     test.done();
   }

--- a/test/sample/loc/en/ignore-this.json
+++ b/test/sample/loc/en/ignore-this.json
@@ -1,0 +1,5 @@
+{
+    "widget-c": {
+        "title": "ignore"
+    }
+}

--- a/test/sample/loc/en/translation-additions.json
+++ b/test/sample/loc/en/translation-additions.json
@@ -1,0 +1,10 @@
+{
+  "widget-b": {
+    "title": "Activities",
+    "has_been": "has been ",
+    "completed": "completed",
+    "added": "added",
+    "deleted": "deleted",
+    "reopened": "reopened"
+  }
+}

--- a/test/sample/loc/en/translation.json
+++ b/test/sample/loc/en/translation.json
@@ -1,0 +1,10 @@
+{
+  "widget-a": {
+    "title": "Activities",
+    "has_been": "has been ",
+    "completed": "completed",
+    "added": "added",
+    "deleted": "deleted",
+    "reopened": "reopened"
+  }
+}


### PR DESCRIPTION
Added:

1. Support for a custom `include` task configuration property to include/exclude files (using the grunt globbing feature)
2. Support for renaming the destination files dynamically, so one task can generate output in multiple destinations (`rename` is a default grunt task configuration property).

Please let me know if you're interested in this. No offence at all if you are not. Not sure if this repo is still active. If not, I'll just have to publish this on npm myself (which I'd like to avoid).

I can add something to the Readme.md as well if you want to merge this. I think we lost NodeJS 0.8 support after upgrading the dependencies, so you might want to publish this as as version 0.1 or 1.0.