### PR TITLE
added: include parameter is now used to ensure files are merged in th…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "6"
+  - "8"
 before_script:
   - npm install -g grunt-cli

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,6 +49,16 @@ module.exports = function(grunt) {
           return dest + src + 'translation-combined.json';
         },
         dest: Path.BUILD_PATH + '/'
+      },
+      together_overwrite: {
+        cwd: 'test/sample/loc',
+        expand: true,
+        src: ['*/'],
+        include: ['**/translation.json', '**/translation-additions.json'],
+        rename: function(dest, src) {
+          return dest + src + 'translation-combined-with-overwrite.json';
+        },
+        dest: Path.BUILD_PATH + '/'
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ i18next: {
 
 ## Release History
 
+* 2017-09-14 v0.2.0 Added support for processing files in a specific order
 * 2016-07-21 v0.1.0 Added support for include and rename
 * 2015-03-04 v0.0.2 Renamed to grunt-i18next
 * 2013-09-28 v0.0.1 First version

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This multi task supports all the file mapping format Grunt supports. Please read
 This required property specifies the *folders* (not files!) the plugin should look for translation json files.
 
 ##### include
-This optional custom property specifies which files to include. If it is omitted, all json files will be included in the specified `src` folders. Any grunt globbing pattern can be used (array or string).
+This optional custom property specifies which files to include and in which order. If it is omitted, all json files will be included in the specified `src` folders. Any grunt globbing pattern can be used (array or string).
 
 ##### dest
 The destination folder.
@@ -55,7 +55,7 @@ i18next: {
 
 ### Complex Usage Example
 
-This task finds .json files in folders that are direct descendents of _src/languages_, excluding files called "ignore-this.json". The task merges all the files in each src folder separately. The resulting files have file names "translation-combined.json", and are placed under _application/languages_ in their own subfolders that match the src subfolders.
+This task finds .json files in folders that are direct descendants of _src/languages_, excluding files called "ignore-this.json". The task merges all the files in each src folder separately. The resulting files have file names "translation-combined.json", and are placed under _application/languages_ in their own subfolders that match the src subfolders.
 
 ```js
 i18next: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-i18next",
   "description": "Bundle language resource files for i18next.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "homepage": "https://github.com/i18next/grunt-i18next",
   "author": {
     "name": "Ignacio Rivas",
@@ -29,8 +29,8 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "1.0.x",
-    "grunt-contrib-clean": "1.0.x",
+    "grunt-contrib-jshint": "1.1.x",
+    "grunt-contrib-clean": "1.1.x",
     "grunt-contrib-nodeunit": "1.0.x",
     "grunt": "1.0.x"
   },

--- a/test/i18next_test.js
+++ b/test/i18next_test.js
@@ -1,7 +1,5 @@
 'use strict';
-//var grunt = require('grunt');
 var fs = require('fs');
-
 var path = 'test/sample/languages/';
 
 exports.spreadOut = {

--- a/test/i18next_test.js
+++ b/test/i18next_test.js
@@ -1,11 +1,11 @@
-var grunt = require('grunt');
+'use strict';
+//var grunt = require('grunt');
 var fs = require('fs');
 
 var path = 'test/sample/languages/';
 
 exports.spreadOut = {
   main: function(test) {
-    'use strict';
 
     test.expect(4);
 
@@ -18,11 +18,10 @@ exports.spreadOut = {
   },
 
   checkBundleContents: function(test) {
-    'use strict';
 
     test.expect(4);
 
-    var 
+    var
       enBundle = JSON.parse(fs.readFileSync(path + 'translation-en.json', 'utf8')),
       nestedBundle = JSON.parse(fs.readFileSync(path + 'nested-en.json', 'utf8'));
 
@@ -38,7 +37,6 @@ exports.spreadOut = {
 
 exports.together = {
   main: function(test) {
-    'use strict';
 
     test.expect(1);
 
@@ -48,7 +46,6 @@ exports.together = {
   },
 
   checkBundleContents: function(test) {
-    'use strict';
 
     test.expect(3);
 
@@ -57,6 +54,28 @@ exports.together = {
     test.equal(enBundle['widget-a'].title, 'Activities', 'The title of widget-a should be Activities.');
     test.equal(enBundle['widget-b'].has_been, 'has been ', 'The has_been attribute of widget-b should be "has been".');
     test.equal(enBundle['widget-c'], undefined, 'The file not included in the "include" property should be ignored.');
+
+    test.done();
+  }
+};
+
+exports.together_overwrite = {
+  main: function(test) {
+
+    test.expect(1);
+
+    test.ok(fs.existsSync(path + 'en/translation-combined-with-overwrite.json'), 'The -combined bundle should exist.');
+
+    test.done();
+  },
+
+  checkBundleContents: function(test) {
+
+    test.expect(1);
+
+    var enBundle = JSON.parse(fs.readFileSync(path + 'en/translation-combined-with-overwrite.json', 'utf8'));
+
+    test.equal(enBundle['widget-a'].title, 'Overwritten', 'The title of widget-a should be Overwritten.');
 
     test.done();
   }

--- a/test/sample/loc/en/translation-additions.json
+++ b/test/sample/loc/en/translation-additions.json
@@ -1,10 +1,13 @@
 {
-  "widget-b": {
-    "title": "Activities",
-    "has_been": "has been ",
-    "completed": "completed",
-    "added": "added",
-    "deleted": "deleted",
-    "reopened": "reopened"
-  }
+    "widget-a": {
+        "title": "Overwritten"
+    },
+    "widget-b": {
+        "title": "Activities",
+        "has_been": "has been ",
+        "completed": "completed",
+        "added": "added",
+        "deleted": "deleted",
+        "reopened": "reopened"
+    }
 }


### PR DESCRIPTION
…e specified order for predictable overwriting of values

Although it looks big, this is just replacing `grunt.file.recurse` with `grunt.file.expand`. The advantage of this change is that we can use the `include` option to re-order files and this way have predictable translation key overwrites.

E.g. if you would like a translation key in b.json to overwrite the same key in a.json, you could use `include: ['a.json', 'b.json']`, or prevent overwriting with `include: ['b.json', 'a.json']`. Until this change the order in which `grunt.file.recurse` processes files was mysterious (not affected by alphabetical order of filenames e.g.).